### PR TITLE
feat: support newer Ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,33 @@
+name: Ruby
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Update the RubyGems system software
+        run: gem update --system
+
+      - name: Update Bundler
+        run: bundle update --bundler
+
+      - name: Install dependencies
+        run: bundle install

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in si.gemspec
 gemspec
+
+gem 'test-unit', '~> 3.6', '>= 3.6.1'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'test-unit', '~> 3.6', '>= 3.6.1'
+gem 'rake', '~> 13.0', '>= 13.0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,21 @@
+PATH
+  remote: .
+  specs:
+    si (0.1.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    power_assert (2.0.3)
+    test-unit (3.6.1)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  si!
+  test-unit (~> 3.6, >= 3.6.1)
+
+BUNDLED WITH
+   2.4.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     power_assert (2.0.3)
+    rake (13.0.6)
     test-unit (3.6.1)
       power_assert
 
@@ -14,6 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  rake (~> 13.0, >= 13.0.6)
   si!
   test-unit (~> 3.6, >= 3.6.1)
 

--- a/lib/si/module.rb
+++ b/lib/si/module.rb
@@ -1,13 +1,13 @@
 module SI
   class << self
     def convert num, options = {}
-      options = { :length => options } if options.is_a?(Fixnum)
+      options = { :length => options } if options.is_a?(Numeric)
       options = DEFAULT.merge(options)
       length,
       min_exp,
       max_exp = options.values_at(:length, :min_exp, :max_exp)
       raise ArgumentError.new("Invalid length") if length < 2
-      return num.is_a?(Fixnum) ? '0' : "0.#{'0' * (length - 1)}" if num == 0
+      return num.is_a?(Float) ? "0.#{'0' * (length - 1)}" : '0' if num == 0
 
       base    = options[:base].to_f
       minus   = num < 0 ? '-' : ''
@@ -18,7 +18,7 @@ module SI
         if nump >= denom || exp == min_exp
           val = nump / denom
           val = SI.round val, [length - val.to_i.to_s.length, 0].max
-          val = val.to_i if exp == 0 && num.is_a?(Fixnum)
+          val = val.to_i if exp == 0 && !num.is_a?(Float)
           val = val.to_s.ljust(length + 1, '0') if val.is_a?(Float)
 
           return "#{minus}#{val}#{PREFIXES[exp]}"

--- a/lib/si/patch.rb
+++ b/lib/si/patch.rb
@@ -1,15 +1,7 @@
-class Float
-  include SI
-end
+['Float', 'Fixnum', 'Bignum', 'Rational', 'Integer'].each do |const|
+  next unless Object.const_defined?(const)
 
-class Fixnum
-  include SI
-end
-
-class Bignum
-  include SI
-end
-
-class Rational
-  include SI
+  Object.const_get(const).class_eval do
+    include SI
+  end
 end

--- a/lib/si/patch.rb
+++ b/lib/si/patch.rb
@@ -1,3 +1,7 @@
+original_verbosity = $VERBOSE
+
+$VERBOSE = nil
+
 ['Float', 'Fixnum', 'Bignum', 'Rational', 'Integer'].each do |const|
   next unless Object.const_defined?(const)
 
@@ -5,3 +9,5 @@
     include SI
   end
 end
+
+$VERBOSE = original_verbosity


### PR DESCRIPTION
This change aims to add support for Ruby 3.2.

Fixes #2

I've tried to make it as safe as possible.

It also includes:

  - Added development dependencies to the `Gemfile`
  - Added `Gemfile.lock` to the repository
  - Silence the deprecation warnings about Fixnum
  - Change the way how the monkey-patching works
  - Added GitHub actions to check against all the Ruby versions the gem supports